### PR TITLE
Add helper text to Cover Block's min-height field

### DIFF
--- a/packages/block-editor/src/components/gradients/README.md
+++ b/packages/block-editor/src/components/gradients/README.md
@@ -1,0 +1,29 @@
+# Gradients
+
+The `Gradients` component exposes tools for working with gradients
+
+<a name="getGradientSlugByValue" href="#getGradientSlugByValue">#</a> **getGradientSlugByValue**
+
+Retrieves the gradient slug per slug.
+
+_Parameters_
+
+-   _gradients_ `Array`: Gradient Palette
+-   _value_ `string`: Gradient value
+
+_Returns_
+
+-   `string`: Gradient slug.
+
+<a name="getGradientValueBySlug" href="#getGradientValueBySlug">#</a> **getGradientValueBySlug**
+
+Retrieves the gradient value per slug.
+
+_Parameters_
+
+-   _gradients_ `Array`: Gradient Palette
+-   _slug_ `string`: Gradient slug
+
+_Returns_
+
+-   `string`: Gradient value.

--- a/packages/block-editor/src/components/navigable-toolbar/README.md
+++ b/packages/block-editor/src/components/navigable-toolbar/README.md
@@ -1,0 +1,16 @@
+# NavigableToolbar
+
+A toolbar that can be navigated with a keyboard
+
+## Props
+
+The component accepts the following props. Props not included in this set will be applied to the element wrapping NavigableMenu content.
+
+## `focusOnMount`
+
+Whether to immediately focus when the component mounts.
+
+- Type: `Boolean`
+- Required: No
+- Default: false
+

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -140,7 +140,13 @@ function CoverHeightInput( {
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
-		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
+		<BaseControl
+			label={ __( 'Minimum height of cover' ) }
+			id={ inputId }
+			help={ __(
+				'The inner content may increase the actual height of the cover block.'
+			) }
+		>
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added helper text to Cover Block's min-height field.

## Why?
The addition of this min-height helper text is to avoid confusion regarding the height of the cover block when inner content is larger than the min-height value.

## How?
The text "The inner content may increase the actual height of the cover block." was added to the help property on the min-height BaseControl.

## Testing Instructions
1. Add a New Page
2. Add a Cover block to the page.
3. In the Cover block sidebar settings you should see the helper text, mentioned above, displayed just below the min-height field.

## Screenshots or screencast 
<img width="278" alt="Screen Shot 2022-04-14 at 11 40 38 AM" src="https://user-images.githubusercontent.com/18356347/163434970-c4747478-2dd0-4357-9591-ff9f813a4ae3.png">

